### PR TITLE
Add Jest setup and simple response test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "seger",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,22 +1,31 @@
-document.getElementById('chat-form').addEventListener('submit', function (e) {
-    e.preventDefault();
-    const input = document.getElementById('fråga');
-    const fråga = input.value;
-    const logg = document.getElementById('chatlog');
-
-    // Visa frågan
-    logg.innerHTML += `<p><strong>Du:</strong> ${fråga}</p>`;
-
-    // Ge ett fördefinierat "låtsassvar"
+function getSvar(fragga) {
     let svar = "Jag är en prototyp. Snart kan jag svara på juridiska frågor om nya lagen.";
-    if (fråga.toLowerCase().includes("barn")) {
-        svar = "I nya socialtjänstlagen betonas barnets rätt till information och delaktighet.";
-    } else if (fråga.toLowerCase().includes("insats utan bistånd")) {
+    const lower = fragga.toLowerCase();
+    if (lower.includes("barn")) {
+        svar = "I nya socialtänstlagen betonas barnets rätt till information och delaktighet.";
+    } else if (lower.includes("insats utan bistånd")) {
         svar = "Ja, nya lagen öppnar upp för insatser utan föregående biståndsbedömning.";
     }
+    return svar;
+}
 
-    // Visa svar
-    logg.innerHTML += `<p><strong>Bot:</strong> ${svar}</p>`;
-    input.value = '';
-    logg.scrollTop = logg.scrollHeight;
-});
+if (typeof document !== 'undefined') {
+    document.getElementById('chat-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+        const input = document.getElementById('fråga');
+        const fråga = input.value;
+        const logg = document.getElementById('chatlog');
+
+        logg.innerHTML += `<p><strong>Du:</strong> ${fråga}</p>`;
+
+        const svar = getSvar(fråga);
+
+        logg.innerHTML += `<p><strong>Bot:</strong> ${svar}</p>`;
+        input.value = '';
+        logg.scrollTop = logg.scrollHeight;
+    });
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { getSvar };
+}

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1,0 +1,6 @@
+const { getSvar } = require('../script');
+
+test('ger barnsvar när frågan innehåller ordet "barn"', () => {
+    const resultat = getSvar('Vad säger lagen om barn?');
+    expect(resultat).toMatch(/barnets rätt/i);
+});


### PR DESCRIPTION
## Summary
- init `package.json` and configure Jest
- extract answer logic into `getSvar` function and export for testing
- add Jest test verifying response when query contains "barn"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684201398cd88329aa900e8217fb1932