### PR TITLE
Add server and client integration for Riksdagen API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# seger
+# Seger
+
+En enkel webbapplikation för att ställa frågor om den svenska socialtjänstlagen.
+
+## Installation
+
+1. Installera beroenden:
+
+```bash
+npm install express
+```
+
+2. Starta servern:
+
+```bash
+node server.js
+```
+
+Applikationen är nu tillgänglig på `http://localhost:3000`.
+
+## API
+
+Servern tillhandahåller ett API som i sin tur hämtar data från riksdagens öppna data.
+
+### `GET /api/riksdagen?q=<sökterm>`
+
+Returnerar JSON-data från riksdagens sök-API. Parametern `q` är den sökterm som skickas vidare till `https://data.riksdagen.se/dokumentlista`.
+
+Exempel:
+
+```
+GET /api/riksdagen?q=barnkonventionen
+```
+
+Svar:
+
+```json
+{
+  "dokumentlista": {
+    "dok": [ ... ]
+  }
+}
+```
+
+Klienten visar de första resultaten i chatten och länkar till respektive dokument hos riksdagen.
+
+## Licens
+
+Se filen [LICENSE](LICENSE).

--- a/script.js
+++ b/script.js
@@ -1,22 +1,28 @@
-document.getElementById('chat-form').addEventListener('submit', function (e) {
+document.getElementById('chat-form').addEventListener('submit', async function (e) {
     e.preventDefault();
     const input = document.getElementById('fråga');
     const fråga = input.value;
     const logg = document.getElementById('chatlog');
 
-    // Visa frågan
     logg.innerHTML += `<p><strong>Du:</strong> ${fråga}</p>`;
-
-    // Ge ett fördefinierat "låtsassvar"
-    let svar = "Jag är en prototyp. Snart kan jag svara på juridiska frågor om nya lagen.";
-    if (fråga.toLowerCase().includes("barn")) {
-        svar = "I nya socialtjänstlagen betonas barnets rätt till information och delaktighet.";
-    } else if (fråga.toLowerCase().includes("insats utan bistånd")) {
-        svar = "Ja, nya lagen öppnar upp för insatser utan föregående biståndsbedömning.";
-    }
-
-    // Visa svar
-    logg.innerHTML += `<p><strong>Bot:</strong> ${svar}</p>`;
     input.value = '';
+
+    try {
+        const res = await fetch(`/api/riksdagen?q=${encodeURIComponent(fråga)}`);
+        const data = await res.json();
+        let svar = 'Hittade inget resultat.';
+        const docs = data.dokumentlista?.dokument || data.dokumentlista?.dok || [];
+        if (docs.length > 0) {
+            const items = docs.slice(0, 5).map(d => {
+                const titel = d.titel || d.ingress || 'Okänt dokument';
+                const url = d.dok_id ? `https://data.riksdagen.se/dokument/${d.dok_id}` : d.url;
+                return `<li><a href="${url}" target="_blank">${titel}</a></li>`;
+            }).join('');
+            svar = `<ul>${items}</ul>`;
+        }
+        logg.innerHTML += `<p><strong>Bot:</strong> ${svar}</p>`;
+    } catch (err) {
+        logg.innerHTML += `<p><strong>Bot:</strong> Kunde inte hämta resultat.</p>`;
+    }
     logg.scrollTop = logg.scrollHeight;
 });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+app.use(express.static(__dirname));
+
+// Endpoint that queries Riksdagen open data API
+app.get('/api/riksdagen', async (req, res) => {
+    const q = req.query.q;
+    if (!q) {
+        return res.status(400).json({ error: 'Missing q parameter' });
+    }
+    try {
+        const url = `https://data.riksdagen.se/dokumentlista/?sok=${encodeURIComponent(q)}&utformat=json`;
+        const response = await fetch(url);
+        const data = await response.json();
+        res.json(data);
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Failed to fetch data from Riksdagen' });
+    }
+});
+
+app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server with `/api/riksdagen` endpoint
- update chat client to fetch data from the new API
- document API usage and setup in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68420182e5908329aae0ea4b8af50209